### PR TITLE
Place item with exact prefix match as the first result

### DIFF
--- a/prefix.js
+++ b/prefix.js
@@ -21,8 +21,16 @@ function searchForPrefix(currentScripts, depth, prefixes, propertyChain, results
       if (!isLastPrefix && isObject(currentScripts[key])) {
         searchForPrefix(currentScripts[key], depth + 1, prefixes, propertyChain, results)
       } else {
-        result[propertyChain.join('.')] = currentScripts[key]
-        results.push(result)
+        var resultKey = propertyChain.join('.')
+        result[resultKey] = currentScripts[key]
+
+        if (resultKey === prefixes.join('.')) {
+          // if we have full match, place it as a first result
+          // because it has biggest relevance
+          results.unshift(result)
+        } else {
+          results.push(result)
+        }
       }
       propertyChain.pop()
     }

--- a/test/prefix.spec.js
+++ b/test/prefix.spec.js
@@ -68,3 +68,12 @@ test('does not flatten results', t => {
     build: 'build things'
   }), [{ watch: { js: 'watch javascript', css: 'watch css' } }])
 })
+
+test('sorts full match first', t => {
+  t.deepEqual(prefix('foo.bar', {
+    foo: {
+      'bar-baz': 'echo "foo.bar-baz"',
+      bar: 'echo "foo.bar"',
+    }
+  }), [{ 'foo.bar': 'echo "foo.bar"' }, { 'foo.bar-baz': 'echo "foo.bar-baz"' }])
+})


### PR DESCRIPTION
This is a possible fix for https://github.com/kentcdodds/nps/issues/116.

If we have a result, that exactly matches requested prefix, we place it at the `results` array beginning (using `unshift`